### PR TITLE
Add macOS foreign configuration

### DIFF
--- a/py4cl2-cffi.asd
+++ b/py4cl2-cffi.asd
@@ -4,6 +4,12 @@
   :serial t
   :components ((:file "config")))
 
+(defsystem "py4cl2-cffi/config-darwin"
+  :pathname #P"src/"
+  :depends-on ("uiop")
+  :serial t
+  :components ((:file "config-darwin")))
+
 (defsystem "py4cl2-cffi"
   :pathname #P"src/"
   :description "CFFI based alternative to PY4CL2, primarily developed for performance reasons."
@@ -21,6 +27,7 @@
                "float-features"
                "parse-number"
                "py4cl2-cffi/config"
+               "py4cl2-cffi/config-darwin"
                "trivial-backtrace"
                "swank")
   :serial t

--- a/src/config-darwin.lisp
+++ b/src/config-darwin.lisp
@@ -1,0 +1,46 @@
+;;;; config.lisp
+
+(defpackage :py4cl2-cffi/config-darwin
+  (:documentation "Configures macOS operating systems.")
+  (:use #:cl
+	#:cl-ppcre
+	:py4cl2-cffi/config))
+(in-package #:py4cl2-cffi/config-darwin)
+
+(defun python-system ()
+  "The path to the Python install or where the virtual environment originates."
+  (read-from-string
+   (with-output-to-string (stream)
+     (uiop:run-program "python -c \"
+import sys
+print(f'(:base-exec-prefix \\\"{sys.base_exec_prefix}\\\"' +
+      f' :exec-prefix \\\"{sys.exec_prefix}\\\")')\""
+		       :output stream)
+     stream)))
+
+(defun configure ()
+  (let* ((ps (python-system))
+	 (prefix (getf ps :base-exec-prefix))
+	 (search-path (getf ps :exec-prefix))
+	 (python-version (ppcre:register-groups-bind (version)
+			     ("^.+\/(.+)?$" prefix :sharedp t)
+			   version))
+	 (path (format nil "~A/" prefix)))
+    (setq
+     py4cl2-cffi/config:*python-shared-object-path*
+     (merge-pathnames (format nil "lib/libpython~A.dylib" python-version) path)
+
+     py4cl2-cffi/config:*python-additional-libraries-search-path*
+     (make-pathname :name search-path)
+
+     py4cl2-cffi/config:*python-compile-command*
+     (concatenate
+      'string
+      "gcc -I'~A' -I'~A' -c -Wall -Werror -fpic py4cl-utils.c && "
+      (format
+       nil
+       "gcc -L'~A/lib' -shared -o libpy4cl-utils.so py4cl-utils.o -lpython~A"
+       path python-version)))))
+
+(if (equal "Darwin" (software-type))
+    (configure))

--- a/src/config.lisp
+++ b/src/config.lisp
@@ -22,7 +22,8 @@
 
 (defvar *python-compile-command*
   (concatenate
-   'string "gcc -I'~A' -I'~A' -c -Wall -Werror -fpic py4cl-utils.c && "
+   'string
+   "gcc -I'~A' -I'~A' -c -Wall -Werror -fpic py4cl-utils.c && "
    "gcc -shared -o libpy4cl-utils.so py4cl-utils.o"))
 
 (defun return-value-as-list (cmd)

--- a/src/config.lisp
+++ b/src/config.lisp
@@ -4,6 +4,7 @@
            #:*python-include-path*
            #:*python-additional-libraries*
            #:*python-additional-libraries-search-path*
+	   #:*python-compile-command*
            #:print-configuration))
 
 (in-package :py4cl2-cffi/config)
@@ -16,6 +17,13 @@
                *python-shared-object-path*
                *python-include-path*
                *python-additional-libraries-search-path*))
+
+(declaim (type string *python-compile-command*))
+
+(defvar *python-compile-command*
+  (concatenate
+   'string "gcc -I'~A' -I'~A' -c -Wall -Werror -fpic py4cl-utils.c && "
+   "gcc -shared -o libpy4cl-utils.so py4cl-utils.o"))
 
 (defun return-value-as-list (cmd)
   (remove ""

--- a/src/python-process.lisp
+++ b/src/python-process.lisp
@@ -177,7 +177,7 @@ can lead to memory leak.")))
     (when *numpy-installed-p*
       (float-features:with-float-traps-masked (:overflow :invalid)
         (ignore-some-conditions (floating-point-overflow floating-point-invalid-operation)
-          (import-module "numpy")
+	  (import-module "numpy")
           (pushnew :typed-arrays *internal-features*)
           (when (member :typed-arrays *internal-features*)
             (setq *numpy-c-api-pointer*

--- a/src/python-process.lisp
+++ b/src/python-process.lisp
@@ -177,8 +177,7 @@ can lead to memory leak.")))
     (when *numpy-installed-p*
       (float-features:with-float-traps-masked (:overflow :invalid)
         (ignore-some-conditions (floating-point-overflow floating-point-invalid-operation)
-	  (import-module "numpy")
-          (pushnew :typed-arrays *internal-features*)
+	  (pushnew :typed-arrays *internal-features*)
           (when (member :typed-arrays *internal-features*)
             (setq *numpy-c-api-pointer*
                   (with-python-gil (foreign-funcall "import_numpy" :pointer)))))))

--- a/src/shared-objects.lisp
+++ b/src/shared-objects.lisp
@@ -25,7 +25,7 @@
                  (zerop error-status))
                (program-string
                  (format nil
-                         "gcc -I'~A' -I'~A' -c -Wall -Werror -fpic py4cl-utils.c && gcc -shared -o libpy4cl-utils.so py4cl-utils.o"
+                         *python-compile-command*
                          (namestring *python-include-path*)
                          (if numpy-installed-p
                              (format nil "~A/core/include/"


### PR DESCRIPTION
This adds macOS as a foreign configuration. I split it out as a separate package because:

* Provides for a cleaner separation from the `config` package as it is a significant chunk of code.
* Allows better a finer level of potential customization to clients.

This pull request also make the compilation command itself a global customizable variable (`*python-compile-command*`).  Doing so made the customization easier to write and allows clients to make other fine tuned adjustments that might be necessary for their respective platforms.