### PR TITLE
Raise Python exceptions as Lisp (pyerror) errors and guard numpy import

### DIFF
--- a/src/py4cl.py
+++ b/src/py4cl.py
@@ -76,6 +76,11 @@ class ExecutionFailure (object):
 		self.stack = traceback.format_exc()
 
 	@property
+	def exception_message(self) -> str:
+		"""The error message."""
+		return str(self.ex)
+
+	@property
 	def exception_type(self) -> str:
 		"""The fully qualified class name of the raised exceptiion."""
 		cn: str = str(type(self.ex))

--- a/src/py4cl.py
+++ b/src/py4cl.py
@@ -1,5 +1,8 @@
 # This file is expected to be executed by RAW-PYEXEC after
 # its contents are read into a string.
+import traceback
+import re
+
 class LispCallbackObject (object):
 	"""
 	Represents a lisp function which can be called.
@@ -63,6 +66,29 @@ class UnknownLispObject (object):
 				ctypes.py_object(attr),
 				ctypes.py_object(value)
 			)
+
+class ExecutionFailure (object):
+	"""
+        Captures a raised exception in the ``raw-py`` Lisp function.
+	"""
+	def __init__(self, ex: Exception):
+		self.ex = ex
+		self.stack = traceback.format_exc()
+
+	@property
+	def exception_type(self) -> str:
+		"""The fully qualified class name of the raised exceptiion."""
+		cn: str = str(type(self.ex))
+		m: re.Match = re.match(r"^<class '(.+)'>$", cn)
+		if m is None:
+			cn = self.ex.__class__.__name__
+		else:
+			cn = m.group(1)
+		return cn
+
+	def __str__(self) -> str:
+		return self.stack
+
 
 def generator(function, stop_value):
 	temp = None

--- a/src/python-process.lisp
+++ b/src/python-process.lisp
@@ -236,6 +236,8 @@ py4cl_utils = ctypes.cdll.LoadLibrary(\"~A\")
                      :initform "A python error occured")
    (format-arguments :initarg :format-arguments
                      :initform ())
+   (exception-message :initarg :exception-message
+		      :initform nil)
    (exception-type   :initarg :exception-type
 		     :initform nil))
   (:report (lambda (condition stream)
@@ -360,7 +362,8 @@ while using RAW-PYEVAL or RAW-PYEXEC.")))
       (error 'pyerror
 	     :format-control (format nil "Python raised an exception:~%~a"
 				     (pyslot-value val "stack"))
-	     :exception-type (pyslot-value val "exception_type")))
+	     :exception-type (pyslot-value val "exception_type")
+	     :exception-message (pyslot-value val "exception_message")))
     (ecase cmd-char
       (#\e (progn
 	     ;; track evaluated instances


### PR DESCRIPTION
The big change with this pull request is to raise a Lisp `pyerror` when a Python error is raised.  It does this by wrapping all evaluated code in a try catch that looks something like:
```python
try:
  _ = <inserted code>
except Exception as e:
  _ = ExecutionFailure(e)
```

Both the stack trace and the error are retained and available in the (modified) `pyerror`.  Example:
```lisp
(handler-case
    (raw-pyexec "raise ValueError('Some error')")
  (pyerror (e)
    (format t "Caught: <~a>~%Message: <~a>~%Exception class: <~a>~%"
	    e
	    (slot-value e 'py4cl2-cffi::exception-message)
	    (slot-value e 'py4cl2-cffi::exception-type))))
```

produces:
```python
Caught: <Python raised an exception:
Traceback (most recent call last):
  File "<string>", line 3, in <module>
ValueError: Some error
>
Message: <Some error>
Exception class: <ValueError>
```

For some unknown reason, I was not able to merge in the changes you made last night so I recreated my fork for this pull request (in case you were wondering or if there's any other git weirdness).