### PR TITLE
Simplify config and accomodate fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,26 +24,20 @@ To load "py4cl2-cffi/config":
 ("py4cl2-cffi/config")
 ```
 
-Set the various configuration parameters in the package `py4cl2/cffi-config` (optionally, first start the lisp process in the virtual environment and then set the configuration parameters):
+For the most part, configuration happens automatically while loading `py4cl2-cffi/config`. This requires that `python3-config` points to the right program in the shell environment in which the lisp is run. Loading `py4cl2-cffi/config` sets the following variables in the `py4cl2-cffi/config` package:
 
-- `*python-additional-libraries*`
-- `*python-additional-libraries-search-path*`
-- `*python-include-path*`
-- `*python-shared-object-path*`
+- `*python-ldflags*`
+- `*python-includes*`
 
-One can use the `python3-config` or equivalent to find these parameters. (See [../.github/workflows/CI-cffi.yml](../.github/workflows/CI-cffi.yml) For instance, the following lisp command sets the parameters to their appropriate values on the author's PC using a miniconda environment:
+In addition, `py4cl2-cffi/config` also exports the following useful symbols:
 
-```lisp
-PY4CL2/CFFI-CONFIG> (setq *python-shared-object-path* #P"/home/user/miniconda3/lib/libpython3.8.so"
-                          *python-include-path* #P"/home/user/miniconda3/include/python3.8/"
-                          *python-additional-libraries-search-path* #P"/home/user/miniconda3/lib/")
-#P"/home/user/miniconda3/lib/"
-```
+- `print-configuration`: It is fbound to a function which prints the ldflags and includes that will be used for the compilation of the utility shared object/library that bridges the python C-API with lisp.
+- `shared-library-from-lflag`: This is fbound to a generic function which takes in two arguments. The first argument is an ldflag (like `-lpython3.10`) and the second argument is the `(software-type)` as a keyword to be used for specialization on the users systems. Each method should return the shared library name associated with that ldflag and software type. For example, when `(intern (string-upcase (software-type)) :keyword)` is `:linux`, the relevant method should return `python3.10.so`.
 
 ### Status
 
 - [x] garbage collection touches
-  - An effort has been made to keep a track of reference counts; but if something is missed, and users notice a memory leak, feel free to [raise an issue](https://github.com/digikar99/py4cl2/issues/new)!
+    - An effort has been made o keep a track of reference counts; but if something is missed, and users notice a memory leak, feel free to [raise an issue](https://github.com/digikar99/py4cl2/issues/new)!
   - trivial-garbage:finalize is used to establish the decref process for the pointer corresponding to the pyobject. However, this requires holding the GIL, and so, the user might need to evaluate `(py4cl2-cffi::pygil-release)` at the top level to release the GIL of the current thread, so that the finalizer thread can then acquire it.
 - [x] function return-values
 - [x] function arguments

--- a/py4cl2-cffi.asd
+++ b/py4cl2-cffi.asd
@@ -27,7 +27,7 @@
                "float-features"
                "parse-number"
                "py4cl2-cffi/config"
-               "py4cl2-cffi/config-darwin"
+               (:feature :darwin "py4cl2-cffi/config-darwin")
                "trivial-backtrace"
                "swank")
   :serial t

--- a/src/config-darwin.lisp
+++ b/src/config-darwin.lisp
@@ -3,8 +3,8 @@
 (defpackage :py4cl2-cffi/config-darwin
   (:documentation "Configures macOS operating systems.")
   (:use #:cl
-	#:cl-ppcre
-	:py4cl2-cffi/config))
+        #:cl-ppcre
+        :py4cl2-cffi/config))
 (in-package #:py4cl2-cffi/config-darwin)
 
 (defun python-system ()
@@ -15,17 +15,17 @@
 import sys
 print(f'(:base-exec-prefix \\\"{sys.base_exec_prefix}\\\"' +
       f' :exec-prefix \\\"{sys.exec_prefix}\\\")')\""
-		       :output stream)
+                       :output stream)
      stream)))
 
 (defun configure ()
   (let* ((ps (python-system))
-	 (prefix (getf ps :base-exec-prefix))
-	 (search-path (getf ps :exec-prefix))
-	 (python-version (ppcre:register-groups-bind (version)
-			     ("^.+\/(.+)?$" prefix :sharedp t)
-			   version))
-	 (path (format nil "~A/" prefix)))
+         (prefix (getf ps :base-exec-prefix))
+         (search-path (getf ps :exec-prefix))
+         (python-version (ppcre:register-groups-bind (version)
+                             ("^.+\/(.+)?$" prefix :sharedp t)
+                           version))
+         (path (format nil "~A/" prefix)))
     (setq
      py4cl2-cffi/config:*python-shared-object-path*
      (merge-pathnames (format nil "lib/libpython~A.dylib" python-version) path)

--- a/src/config.lisp
+++ b/src/config.lisp
@@ -1,10 +1,8 @@
 (defpackage :py4cl2-cffi/config
   (:use :cl)
-  (:export #:*python-shared-object-path*
-           #:*python-include-path*
-           #:*python-additional-libraries*
-           #:*python-additional-libraries-search-path*
-	   #:*python-compile-command*
+  (:export #:*python-ldflags*
+           #:*python-includes*
+           #:*python-compile-command*
            #:print-configuration))
 
 (in-package :py4cl2-cffi/config)
@@ -13,17 +11,19 @@
 
 ;; TODO: Could set up better defaults for different OS
 
-(declaim (type pathname
-               *python-shared-object-path*
-               *python-include-path*
-               *python-additional-libraries-search-path*))
+(declaim (type list
+               *python-ldflags*
+               *python-includes*))
 
 (declaim (type string *python-compile-command*))
 
 (defvar *python-compile-command*
   (concatenate
    'string
-   "gcc -I'~A' -I'~A' -c -Wall -Werror -fpic py4cl-utils.c && "
+   ;; The first ~A corresponds to the *python-includes* defined below.
+   ;; The second ~A corresponds to the numpy include files discovered
+   ;;   in shared-objects.lisp
+   "gcc ~A -I'~A' -c -Wall -Werror -fpic py4cl-utils.c && "
    "gcc -shared -o libpy4cl-utils.so py4cl-utils.o"))
 
 (defun return-value-as-list (cmd)
@@ -35,42 +35,16 @@
                                           :error-output *error-output*)))
           :test #'string=))
 
-(defun strip-i-and-l (arg)
-  (declare (type string arg))
-  (cond ((< (length arg) 2)
-         arg)
-        ((member (subseq arg 0 2)
-                 '("-i" "-l")
-                 :test #'string-equal)
-         (subseq arg 2))
-        (t
-         arg)))
-
 (let ((python-version-string (second (return-value-as-list "python3 --version"))))
   (if (uiop:version< python-version-string "3.8.0")
-      (destructuring-bind (libpython-path more-libs-path &rest more-libs)
-          (mapcar #'strip-i-and-l
-                  (return-value-as-list "python3-config --ldflags"))
-        (defvar *python-shared-object-path*
-          (let ((libpython (apply #'format nil "python~D.~D"
-                                  (subseq (uiop:parse-version python-version-string)
-                                          0 2))))
-            (pathname (uiop:strcat libpython-path "/lib" libpython ".so"))))
-        (defvar *python-additional-libraries* more-libs)
-        (defvar *python-additional-libraries-search-path* (pathname more-libs-path)))
-      (destructuring-bind (libpython-path more-libs-path libpython &rest more-libs)
-          (mapcar #'strip-i-and-l
-                  (return-value-as-list "python3-config --embed --ldflags"))
-        (defvar *python-shared-object-path*
-          (pathname (uiop:strcat libpython-path "/lib" libpython ".so")))
-        (defvar *python-additional-libraries* more-libs)
-        (defvar *python-additional-libraries-search-path* (pathname more-libs-path)))))
+      (defvar *python-ldflags* (return-value-as-list "python3-config --ldflags"))
+      (defvar *python-ldflags*
+        (return-value-as-list "python3-config --embed --ldflags"))))
 
-(defvar *python-include-path*
-  (pathname (strip-i-and-l (nth 0 (return-value-as-list "python3-config --includes")))))
+(defvar *python-includes*
+  (return-value-as-list "python3-config --includes"))
 
 (defun print-configuration ()
-  (format t "Python Shared Object Path: ~A~%Python Include Path: ~A~%Python Ldflags Search Path: ~A~%"
-          *python-shared-object-path*
-          *python-include-path*
-          *python-additional-libraries-search-path*))
+  (format t "Python ldflags: ~A~%Python includes: ~A~%"
+          *python-ldflags*
+          *python-includes*))

--- a/src/config.lisp
+++ b/src/config.lisp
@@ -3,7 +3,8 @@
   (:export #:*python-ldflags*
            #:*python-includes*
            #:*python-compile-command*
-           #:print-configuration))
+           #:print-configuration
+           #:shared-library-from-lflag))
 
 (in-package :py4cl2-cffi/config)
 
@@ -45,6 +46,22 @@
   (return-value-as-list "python3-config --includes"))
 
 (defun print-configuration ()
-  (format t "Python ldflags: ~A~%Python includes: ~A~%"
+  (format t "Python ldflags: ~{~A~^ ~}~%Python includes: ~{~A~^ ~}~%"
           *python-ldflags*
           *python-includes*))
+
+(defun %shared-library-from-lflag (lflag)
+  "Given a lflag, for example, \"-lpython3.10\", return the shared library name
+corresponding to it. In this case, on linux, it will return libpython3.10.so"
+  (shared-library-from-lflag lflag
+                             (intern (string-upcase (software-type))
+                                     :keyword)))
+
+(defmethod shared-library-from-lflag (lflag (software-type (eql :linux)))
+  (format nil "lib~A.so" (subseq lflag 2)))
+
+(defmethod shared-library-from-lflag (lflag (software-type (eql :darwin)))
+  (format nil "lib~A.dylib" (subseq lflag 2)))
+
+(defmethod shared-library-from-lflag (lflag (software-type (eql :windows)))
+  (format nil "lib~A.dll" (subseq lflag 2)))

--- a/src/config.lisp
+++ b/src/config.lisp
@@ -46,6 +46,8 @@
   (return-value-as-list "python3-config --includes"))
 
 (defun print-configuration ()
+  "Prints the ldflags and includes that will be used for the compilation
+of the utility shared object/library that bridges the python C-API with lisp."
   (format t "Python ldflags: ~{~A~^ ~}~%Python includes: ~{~A~^ ~}~%"
           *python-ldflags*
           *python-includes*))
@@ -57,6 +59,8 @@ corresponding to it. In this case, on linux, it will return libpython3.10.so"
                              (intern (string-upcase (software-type))
                                      :keyword)))
 
+(defgeneric shared-library-from-ldflag (ldflag software-type)
+  (:documentation "This is a generic function which takes in two arguments. The first argument is an ldflag (like `-lpython3.10`) and the second argument is the `(software-type)` as a keyword to be used for specialization on the users systems. Each method should return the shared library name associated with that ldflag and software type. For example, when `(intern (string-upcase (software-type)) :keyword)` is `:linux`, the relevant method should return `python3.10.so`"))
 
 (defmethod shared-library-from-ldflag (ldflag (software-type (eql :linux)))
   (format nil "lib~A.so" (subseq ldflag 2)))

--- a/src/config.lisp
+++ b/src/config.lisp
@@ -4,7 +4,7 @@
            #:*python-includes*
            #:*python-compile-command*
            #:print-configuration
-           #:shared-library-from-lflag))
+           #:shared-library-from-ldflag))
 
 (in-package :py4cl2-cffi/config)
 
@@ -50,18 +50,19 @@
           *python-ldflags*
           *python-includes*))
 
-(defun %shared-library-from-lflag (lflag)
-  "Given a lflag, for example, \"-lpython3.10\", return the shared library name
+(defun %shared-library-from-ldflag (ldflag)
+  "Given a ldflag, for example, \"-lpython3.10\", return the shared library name
 corresponding to it. In this case, on linux, it will return libpython3.10.so"
-  (shared-library-from-lflag lflag
+  (shared-library-from-ldflag ldflag
                              (intern (string-upcase (software-type))
                                      :keyword)))
 
-(defmethod shared-library-from-lflag (lflag (software-type (eql :linux)))
-  (format nil "lib~A.so" (subseq lflag 2)))
 
-(defmethod shared-library-from-lflag (lflag (software-type (eql :darwin)))
-  (format nil "lib~A.dylib" (subseq lflag 2)))
+(defmethod shared-library-from-ldflag (ldflag (software-type (eql :linux)))
+  (format nil "lib~A.so" (subseq ldflag 2)))
 
-(defmethod shared-library-from-lflag (lflag (software-type (eql :windows)))
-  (format nil "lib~A.dll" (subseq lflag 2)))
+(defmethod shared-library-from-ldflag (ldflag (software-type (eql :darwin)))
+  (format nil "lib~A.dylib" (subseq ldflag 2)))
+
+(defmethod shared-library-from-ldflag (ldflag (software-type (eql :windows)))
+  (format nil "lib~A.dll" (subseq ldflag 2)))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -1,5 +1,7 @@
 (defpackage :py4cl2-cffi
   (:use :cl :cffi :alexandria :py4cl2-cffi/config :iterate)
+  (:import-from #:py4cl2-cffi/config
+                #:%shared-library-from-lflag)
   (:export #:*internal-features*
 
            #:with-pygc

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -1,7 +1,7 @@
 (defpackage :py4cl2-cffi
   (:use :cl :cffi :alexandria :py4cl2-cffi/config :iterate)
   (:import-from #:py4cl2-cffi/config
-                #:%shared-library-from-lflag)
+                #:%shared-library-from-ldflag)
   (:export #:*internal-features*
 
            #:with-pygc

--- a/src/python-process.lisp
+++ b/src/python-process.lisp
@@ -6,16 +6,6 @@
 (defvar *python-libraries-loaded-p* nil)
 (defvar *in-with-remote-objects-p* nil)
 
-(defun load-python-and-libraries ()
-  (load-foreign-library *python-shared-object-path*)
-  (dolist (lib (loop :for lib :in *python-additional-libraries*
-                     :nconcing
-                     (uiop:directory-files
-                      *python-additional-libraries-search-path* (format nil "lib~A.so*" lib))))
-    (load-foreign-library lib))
-  (load-foreign-library *utils-shared-object-path*)
-  (setq *python-libraries-loaded-p* t))
-
 (defvar *python-state* :uninitialized)
 (declaim (type (member :uninitialized :initialized :initializing) *python-state*))
 

--- a/src/shared-objects.lisp
+++ b/src/shared-objects.lisp
@@ -84,7 +84,7 @@
                               (push (ensure-directory-name (subseq flag 2))
                                     search-paths))
                              ((starts-with-subseq "-l" flag :test #'char=)
-                              (push (format nil "lib~A.so" (subseq flag 2))
+                              (push (%shared-library-from-lflag flag)
                                     libraries)))
                    :finally (return (values (nreverse libraries)
                                             (nreverse search-paths))))))

--- a/src/shared-objects.lisp
+++ b/src/shared-objects.lisp
@@ -84,7 +84,7 @@
                               (push (ensure-directory-name (subseq flag 2))
                                     search-paths))
                              ((starts-with-subseq "-l" flag :test #'char=)
-                              (push (%shared-library-from-lflag flag)
+                              (push (%shared-library-from-ldflag flag)
                                     libraries)))
                    :finally (return (values (nreverse libraries)
                                             (nreverse search-paths))))))


### PR DESCRIPTION
We could avoid a good chunk of the intermediate parsing and unparsing of the config variables, while also being able to accomodate more systems.