### PR TITLE
Fix dependencies of system PY4CL2-CFFI/CONFIG-DARWIN.

### DIFF
--- a/py4cl2-cffi.asd
+++ b/py4cl2-cffi.asd
@@ -6,7 +6,7 @@
 
 (defsystem "py4cl2-cffi/config-darwin"
   :pathname #P"src/"
-  :depends-on ("uiop")
+  :depends-on ("cl-ppcre" "py4cl2-cffi/config" "uiop")
   :serial t
   :components ((:file "config-darwin")))
 


### PR DESCRIPTION
The system definition includes file src/config-darwin.lisp, which uses symbols in packages CL-PPCRE and PY4CL2-CFFI/CONFIG, so the system needs to depend on the systems that define those symbols.