### PR TITLE
Fix init bug for when the exec "python" is missing.

### DIFF
--- a/src/config-darwin.lisp
+++ b/src/config-darwin.lisp
@@ -7,15 +7,30 @@
         :py4cl2-cffi/config))
 (in-package #:py4cl2-cffi/config-darwin)
 
+(defun python-executable ()
+  "Determine if the name of the python executable."
+  (or (multiple-value-bind (_ e)
+          (ignore-errors (uiop:run-program "which python"))
+        (declare (ignore _))
+        (unless e "python"))
+      (multiple-value-bind (_ e)
+          (ignore-errors (uiop:run-program "which python3"))
+        (declare (ignore _))
+        (unless e "python3"))
+      (error "Python executable not found.")))
+
 (defun python-system ()
   "The path to the Python install or where the virtual environment originates."
   (read-from-string
    (with-output-to-string (stream)
-     (uiop:run-program "python -c \"
+     (uiop:run-program
+      (format nil
+              "~a -c \"
 import sys
 print(f'(:base-exec-prefix \\\"{sys.base_exec_prefix}\\\"' +
       f' :exec-prefix \\\"{sys.exec_prefix}\\\")')\""
-                       :output stream)
+              (python-executable))
+      :output stream)
      stream)))
 
 (defun configure ()


### PR DESCRIPTION
Thank you for your support with darwin! I've made a necessary adjustment to ensure successful loading into my Lisp environment. The root cause was the absence of python, which led me to realize that only python3 is available. 

This modification makes the system determine whether the executable is called `python` or `python3`, and use the found one. With this modification, users encountering the same issue will now identify the problem more readily, especially if they solely have python3.

Following this fix, I've confirmed functionality through the following tests:

``` lisp
PY4CL2-CFFI> (raw-pyexec "def foo(fn, *args, **kwargs): return fn(*args, **kwargs)")
; No value
PY4CL2-CFFI> (pycall "foo" (lambda (d e &rest args &key a b &allow-other-keys)
                             (declare (ignore a b))
                             (list* d e args))
                     8 9 :a 2 :b 3 :d 5)
(8 9 "d" 5 "b" 3 "a" 2)

PY4CL2-CFFI> (asdf:test-system "py4cl2-tests")
T
```

Please let me know if you want me to change any thing else. And feel free to reach out if you want me to test `py4cl2-cffi` and offer fixes on darwin.

Cheers!
Jin