### PR TITLE
Fix numpy-installed-p to work with case sensitive lisps

### DIFF
--- a/src/shared-objects.lisp
+++ b/src/shared-objects.lisp
@@ -74,7 +74,7 @@
                                                    :ignore-error-status t))))
              (numpy-installed-p-new
                (with-standard-io-syntax
-                 (write-to-string `(quote ,numpy-installed-p)))))
+                 (write-to-string numpy-installed-p))))
         (when (or error
                   (string/= numpy-installed-p-old
                             numpy-installed-p-new))


### PR DESCRIPTION
T never has to be quoted (it evaluates to itself), so get rid of the  (quote ... ) in the  numpy-installed-p file.  Has the advantage or producing t in case sensitive lisps as well.