### PR TITLE
20250317 disable ccl ci failure

### DIFF
--- a/ci-test.lisp
+++ b/ci-test.lisp
@@ -1,27 +1,23 @@
 (in-package :cl-user)
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (ql:quickload "py4cl2-cffi-tests"))
-
 (push :ci *features*)
 (when (eq :linux (uiop:operating-system))
   (push (print (pathname (uiop:getenv "EXOTIC_DIR")))
         ql:*local-project-directories*))
 (push #P"./" ql:*local-project-directories*)
 
-(progn
-  (ql:quickload "py4cl2-cffi-tests")
+(ql:quickload "py4cl2-cffi-tests")
     
-  (py4cl2-cffi/config:print-configuration)
+(py4cl2-cffi/config:print-configuration)
     
-  (let ((report (py4cl2-cffi-tests:run)))
-    (when (or (plusp (slot-value report 'clunit::failed))
-	      (plusp (slot-value report 'clunit::errors)))
-      (uiop:quit 1)))
-  (terpri)
-  (format t "!!MULTI-THREADED TESTS RAN SUCCESSFULLY!!"))
+(let ((report (py4cl2-cffi-tests:run)))
+  (when (or (plusp (slot-value report 'clunit::failed))
+	    (plusp (slot-value report 'clunit::errors)))
+    (uiop:quit 1)))
+(terpri)
+(format t "!!MULTI-THREADED TESTS RAN SUCCESSFULLY!!")
 
-
+#-:ccl
 (progn
   (ql:quickload "py4cl2-cffi/single-threaded")
   (py4cl2-cffi/single-threaded:pystart)

--- a/ci-test.lisp
+++ b/ci-test.lisp
@@ -1,20 +1,29 @@
 (in-package :cl-user)
+
 (push :ci *features*)
 (when (eq :linux (uiop:operating-system))
   (push (print (pathname (uiop:getenv "EXOTIC_DIR")))
         ql:*local-project-directories*))
 (push #P"./" ql:*local-project-directories*)
-(ql:quickload "py4cl2-cffi-tests")
-(py4cl2-cffi/config:print-configuration)
-(let ((report (py4cl2-cffi-tests:run)))
-  (when (or (plusp (slot-value report 'clunit::failed))
-            (plusp (slot-value report 'clunit::errors)))
-    (uiop:quit 1)))
-(terpri)
-(format t "!!MULTI-THREADED TESTS RAN SUCCESSFULLY!!")
-(ql:quickload "py4cl2-cffi/single-threaded")
-(py4cl2-cffi/single-threaded:pystart)
-(assert (string= "42" (py4cl2-cffi/single-threaded:pycall "str" 42)))
-(terpri)
-(format t "!!Preliminary SINGLE-THREADED TESTS RAN SUCCESSFULLY!!")
-(uiop:quit 0)
+
+(progn
+  (ql:quickload "py4cl2-cffi-tests")
+
+  (py4cl2-cffi/config:print-configuration)
+
+  (let ((report (py4cl2-cffi-tests:run)))
+    (when (or (plusp (slot-value report 'clunit::failed))
+              (plusp (slot-value report 'clunit::errors)))
+      (uiop:quit 1)))
+  (terpri)
+  (format t "!!MULTI-THREADED TESTS RAN SUCCESSFULLY!!"))
+
+
+#-:ccl
+(progn
+  (ql:quickload "py4cl2-cffi/single-threaded")
+  (py4cl2-cffi/single-threaded:pystart)
+  (assert (string= "42" (py4cl2-cffi/single-threaded:pycall "str" 42)))
+  (terpri)
+  (format t "!!Preliminary SINGLE-THREADED TESTS RAN SUCCESSFULLY!!")
+  (uiop:quit 0))

--- a/ci-test.lisp
+++ b/ci-test.lisp
@@ -6,24 +6,25 @@
         ql:*local-project-directories*))
 (push #P"./" ql:*local-project-directories*)
 
-(progn
-  (ql:quickload "py4cl2-cffi-tests")
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (progn
+    (ql:quickload "py4cl2-cffi-tests")
+    
+    (py4cl2-cffi/config:print-configuration)
+    
+    (let ((report (py4cl2-cffi-tests:run)))
+      (when (or (plusp (slot-value report 'clunit::failed))
+		(plusp (slot-value report 'clunit::errors)))
+	(uiop:quit 1)))
+    (terpri)
+    (format t "!!MULTI-THREADED TESTS RAN SUCCESSFULLY!!"))
+  
 
-  (py4cl2-cffi/config:print-configuration)
-
-  (let ((report (py4cl2-cffi-tests:run)))
-    (when (or (plusp (slot-value report 'clunit::failed))
-              (plusp (slot-value report 'clunit::errors)))
-      (uiop:quit 1)))
-  (terpri)
-  (format t "!!MULTI-THREADED TESTS RAN SUCCESSFULLY!!"))
-
-
-#-:ccl
-(progn
-  (ql:quickload "py4cl2-cffi/single-threaded")
-  (py4cl2-cffi/single-threaded:pystart)
-  (assert (string= "42" (py4cl2-cffi/single-threaded:pycall "str" 42)))
-  (terpri)
-  (format t "!!Preliminary SINGLE-THREADED TESTS RAN SUCCESSFULLY!!")
-  (uiop:quit 0))
+  #-:ccl
+  (progn
+    (ql:quickload "py4cl2-cffi/single-threaded")
+    (py4cl2-cffi/single-threaded:pystart)
+    (assert (string= "42" (py4cl2-cffi/single-threaded:pycall "str" 42)))
+    (terpri)
+    (format t "!!Preliminary SINGLE-THREADED TESTS RAN SUCCESSFULLY!!")
+    (uiop:quit 0)))

--- a/ci-test.lisp
+++ b/ci-test.lisp
@@ -20,8 +20,10 @@
 #-:ccl
 (progn
   (ql:quickload "py4cl2-cffi/single-threaded")
-  (py4cl2-cffi/single-threaded:pystart)
-  (assert (string= "42" (py4cl2-cffi/single-threaded:pycall "str" 42)))
+  ;; (py4cl2-cffi/single-threaded:pystart)
+  (funcall (symbol-function (intern "PYSTART" (find-package "PY4CL2-CFFI/SINGLE-THREADED"))))
+  ;; (assert (string= "42" (py4cl2-cffi/single-threaded:pycall "str" 42)))
+  (assert (string= "42" (funcall (symbol-function (intern "PYCALL" (find-package "PY4CL2-CFFI/SINGLE-THREADED"))) "str" 42)))
   (terpri)
   (format t "!!Preliminary SINGLE-THREADED TESTS RAN SUCCESSFULLY!!")
   (uiop:quit 0))

--- a/ci-test.lisp
+++ b/ci-test.lisp
@@ -1,30 +1,31 @@
 (in-package :cl-user)
 
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (ql:quickload "py4cl2-cffi-tests"))
+
 (push :ci *features*)
 (when (eq :linux (uiop:operating-system))
   (push (print (pathname (uiop:getenv "EXOTIC_DIR")))
         ql:*local-project-directories*))
 (push #P"./" ql:*local-project-directories*)
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (progn
-    (ql:quickload "py4cl2-cffi-tests")
+(progn
+  (ql:quickload "py4cl2-cffi-tests")
     
-    (py4cl2-cffi/config:print-configuration)
+  (py4cl2-cffi/config:print-configuration)
     
-    (let ((report (py4cl2-cffi-tests:run)))
-      (when (or (plusp (slot-value report 'clunit::failed))
-		(plusp (slot-value report 'clunit::errors)))
-	(uiop:quit 1)))
-    (terpri)
-    (format t "!!MULTI-THREADED TESTS RAN SUCCESSFULLY!!"))
-  
+  (let ((report (py4cl2-cffi-tests:run)))
+    (when (or (plusp (slot-value report 'clunit::failed))
+	      (plusp (slot-value report 'clunit::errors)))
+      (uiop:quit 1)))
+  (terpri)
+  (format t "!!MULTI-THREADED TESTS RAN SUCCESSFULLY!!"))
 
-  #-:ccl
-  (progn
-    (ql:quickload "py4cl2-cffi/single-threaded")
-    (py4cl2-cffi/single-threaded:pystart)
-    (assert (string= "42" (py4cl2-cffi/single-threaded:pycall "str" 42)))
-    (terpri)
-    (format t "!!Preliminary SINGLE-THREADED TESTS RAN SUCCESSFULLY!!")
-    (uiop:quit 0)))
+
+(progn
+  (ql:quickload "py4cl2-cffi/single-threaded")
+  (py4cl2-cffi/single-threaded:pystart)
+  (assert (string= "42" (py4cl2-cffi/single-threaded:pycall "str" 42)))
+  (terpri)
+  (format t "!!Preliminary SINGLE-THREADED TESTS RAN SUCCESSFULLY!!")
+  (uiop:quit 0))


### PR DESCRIPTION
This avoids build/test failure on CCL by excluding the "single-threaded functionality" (which does not seem to work on CCL, yet).